### PR TITLE
Object system wants "x_smtpapi" but API wants "x-smtpapi" to work

### DIFF
--- a/lib/Mojo/Sendgrid/Mail.pm
+++ b/lib/Mojo/Sendgrid/Mail.pm
@@ -36,7 +36,7 @@ sub send {
 # Create the hash to be supplied to the form option of Mojo::UserAgent
 sub _form {
   my $self = shift->_require_one;
-  return {map {$_=>$self->$_} grep {$self->$_} @{$parameters{send}{required}}, @{$parameters{send}{optional}}};
+  return {map {($_=~s/_/-/r)=>$self->$_} grep {$self->$_} @{$parameters{send}{required}}, @{$parameters{send}{optional}}};
 }
 
 # I don't know how else to enforce requiring at least one attribute of a group
@@ -147,7 +147,7 @@ Content IDs of the files to be used as inline images.
 
 A collection of key/value pairs in JSON format.
 
-=head2 x-smtpapi
+=head2 x_smtpapi
 
 Please review the SMTP API to view documentation on what you can do with the
 JSON headers.


### PR DESCRIPTION
"x_smtpapi" is used as a convenience name for the Mojo::Base object optional parameter/attribute. The parameters are passed in bulk to the form option of Mojo::UserAgent->post. Unchanged, however, "x_smtpapi" is silently dropped by the SendGrid API; it expects the field "x-smtpapi" to function properly.

I also made an adjustment to the documentation to reflect the expected parameter/attribute name for "x_smtpapi".

I used s///r to keep things terse, but this would bump up the minimum Perl requirement to v5.13.2.

My particular motivation was to get categories working, and the SMTPAPI seems to be the only way to get them through.
